### PR TITLE
Adding Witness Location + Timestamp

### DIFF
--- a/migrations/0003_add_location_columns_to_challenge_receipts_parsed.sql
+++ b/migrations/0003_add_location_columns_to_challenge_receipts_parsed.sql
@@ -1,0 +1,3 @@
+alter table challenge_receipts_parsed
+add column witness_location text,
+add column witness_timestamp text;

--- a/views/challenge_receipts_parsed.sql
+++ b/views/challenge_receipts_parsed.sql
@@ -28,7 +28,10 @@ SELECT  a.block, a.hash, a.challengee,
         b.value::json->>'is_valid' as witness_is_valid,
         b.value::json->>'invalid_reason' as witness_invalid_reason,
         b.value::json->>'signal' as witness_signal,
-        b.value::json->>'snr' as witness_snr
+        b.value::json->>'snr' as witness_snr,
+        b.value::json->>'channel' as witness_channel,
+        b.value::json->>'datarate' as witness_sf,
+        b.value::json->>'frequency' as witness_frequency
 from    data2 a, json_array_elements(a.witnesses::json) b
 ),
 hotspot1 as (
@@ -38,7 +41,7 @@ from    gateway_inventory
 Insert into challenge_receipts_parsed
 select  a.block, a.hash, a.time, h.name as transmitter_name, a.challengee_gateway as transmitter_address, a.origin,
         b.witness_owner, wt.name as witness_name, b.witness_gateway, COALESCE(b.witness_is_valid, 'No Witness') as witness_is_valid,
-        b.witness_invalid_reason, b.witness_signal, b.witness_snr
+        b.witness_invalid_reason, b.witness_signal, b.witness_snr, b.witness_channel, b.witness_sf, b.witness_frequency
 from    data_r1 a
 join    hotspot1 h
     on  a.challengee_gateway = h.address

--- a/views/challenge_receipts_parsed.sql
+++ b/views/challenge_receipts_parsed.sql
@@ -32,6 +32,8 @@ SELECT  a.block, a.hash, a.challengee,
         b.value::json->>'channel' as witness_channel,
         b.value::json->>'datarate' as witness_sf,
         b.value::json->>'frequency' as witness_frequency
+        b.value::json->>'location' as witness_location
+        b.value::json->>'timestamp' as witness_timestamp
 from    data2 a, json_array_elements(a.witnesses::json) b
 ),
 hotspot1 as (
@@ -41,7 +43,8 @@ from    gateway_inventory
 Insert into challenge_receipts_parsed
 select  a.block, a.hash, a.time, h.name as transmitter_name, a.challengee_gateway as transmitter_address, a.origin,
         b.witness_owner, wt.name as witness_name, b.witness_gateway, COALESCE(b.witness_is_valid, 'No Witness') as witness_is_valid,
-        b.witness_invalid_reason, b.witness_signal, b.witness_snr, b.witness_channel, b.witness_sf, b.witness_frequency
+        b.witness_invalid_reason, b.witness_signal, b.witness_snr, b.witness_channel, b.witness_sf, b.witness_frequency,
+        b.witness_location, b.witness_timestamp
 from    data_r1 a
 join    hotspot1 h
     on  a.challengee_gateway = h.address


### PR DESCRIPTION
Gateways table only contains beaconing hotspot's location so adding witness location to challenge receipts parsed is helpful.