### PR TITLE
Add view for validator_cg_members

### DIFF
--- a/etl-schema.sql
+++ b/etl-schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.15 (Ubuntu 10.15-0ubuntu0.18.04.1)
--- Dumped by pg_dump version 10.15 (Ubuntu 10.15-0ubuntu0.18.04.1)
+-- Dumped from database version 10.17 (Ubuntu 10.17-0ubuntu0.18.04.1)
+-- Dumped by pg_dump version 10.17 (Ubuntu 10.17-0ubuntu0.18.04.1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -17,6 +17,22 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: topology; Type: SCHEMA; Schema: -; Owner: etl
+--
+
+CREATE SCHEMA topology;
+
+
+ALTER SCHEMA topology OWNER TO etl;
+
+--
+-- Name: SCHEMA topology; Type: COMMENT; Schema: -; Owner: etl
+--
+
+COMMENT ON SCHEMA topology IS 'PostGIS Topology schema';
+
+
+--
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
 --
 
@@ -28,6 +44,20 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 --
 
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
+-- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQL statements executed';
 
 
 --
@@ -45,6 +75,49 @@ COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching
 
 
 --
+-- Name: postgis; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION postgis; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION postgis IS 'PostGIS geometry, geography, and raster spatial types and functions';
+
+
+--
+-- Name: burn_type; Type: TYPE; Schema: public; Owner: etl
+--
+
+CREATE TYPE public.burn_type AS ENUM (
+    'fee',
+    'state_channel',
+    'assert_location',
+    'add_gateway',
+    'oui',
+    'routing'
+);
+
+
+ALTER TYPE public.burn_type OWNER TO etl;
+
+--
+-- Name: gateway_mode; Type: TYPE; Schema: public; Owner: etl
+--
+
+CREATE TYPE public.gateway_mode AS ENUM (
+    'full',
+    'light',
+    'dataonly'
+);
+
+
+ALTER TYPE public.gateway_mode OWNER TO etl;
+
+--
 -- Name: gateway_status_online; Type: TYPE; Schema: public; Owner: etl
 --
 
@@ -53,6 +126,22 @@ CREATE TYPE public.gateway_status_online AS ENUM (
     'offline'
 );
 
+
+ALTER TYPE public.gateway_status_online OWNER TO etl;
+
+--
+-- Name: packet_entry; Type: TYPE; Schema: public; Owner: etl
+--
+
+CREATE TYPE public.packet_entry AS (
+	client text,
+	type text,
+	num_packets bigint,
+	num_dcs bigint
+);
+
+
+ALTER TYPE public.packet_entry OWNER TO etl;
 
 --
 -- Name: pending_transaction_nonce_type; Type: TYPE; Schema: public; Owner: etl
@@ -66,6 +155,8 @@ CREATE TYPE public.pending_transaction_nonce_type AS ENUM (
 );
 
 
+ALTER TYPE public.pending_transaction_nonce_type OWNER TO etl;
+
 --
 -- Name: pending_transaction_status; Type: TYPE; Schema: public; Owner: etl
 --
@@ -78,6 +169,8 @@ CREATE TYPE public.pending_transaction_status AS ENUM (
 );
 
 
+ALTER TYPE public.pending_transaction_status OWNER TO etl;
+
 --
 -- Name: reward_entry; Type: TYPE; Schema: public; Owner: etl
 --
@@ -89,6 +182,8 @@ CREATE TYPE public.reward_entry AS (
 	amount bigint
 );
 
+
+ALTER TYPE public.reward_entry OWNER TO etl;
 
 --
 -- Name: transaction_actor_role; Type: TYPE; Schema: public; Owner: etl
@@ -108,9 +203,13 @@ CREATE TYPE public.transaction_actor_role AS ENUM (
     'sc_opener',
     'sc_closer',
     'packet_receiver',
-    'oracle'
+    'oracle',
+    'router',
+    'validator'
 );
 
+
+ALTER TYPE public.transaction_actor_role OWNER TO etl;
 
 --
 -- Name: transaction_type; Type: TYPE; Schema: public; Owner: etl
@@ -140,9 +239,45 @@ CREATE TYPE public.transaction_type AS ENUM (
     'state_channel_open_v1',
     'state_channel_close_v1',
     'price_oracle_v1',
-    'transfer_hotspot_v1'
+    'transfer_hotspot_v1',
+    'rewards_v2',
+    'assert_location_v2',
+    'gen_validator_v1',
+    'stake_validator_v1',
+    'unstake_validator_v1',
+    'validator_heartbeat_v1',
+    'transfer_validator_stake_v1',
+    'gen_price_oracle_v1',
+    'consensus_group_failure_v1'
 );
 
+
+ALTER TYPE public.transaction_type OWNER TO etl;
+
+--
+-- Name: validator_status_online; Type: TYPE; Schema: public; Owner: etl
+--
+
+CREATE TYPE public.validator_status_online AS ENUM (
+    'online',
+    'offline'
+);
+
+
+ALTER TYPE public.validator_status_online OWNER TO etl;
+
+--
+-- Name: validator_status_type; Type: TYPE; Schema: public; Owner: etl
+--
+
+CREATE TYPE public.validator_status_type AS ENUM (
+    'staked',
+    'cooldown',
+    'unstaked'
+);
+
+
+ALTER TYPE public.validator_status_type OWNER TO etl;
 
 --
 -- Name: var_type; Type: TYPE; Schema: public; Owner: etl
@@ -156,14 +291,18 @@ CREATE TYPE public.var_type AS ENUM (
 );
 
 
+ALTER TYPE public.var_type OWNER TO etl;
+
 --
 -- Name: account_inventory_update(); Type: FUNCTION; Schema: public; Owner: etl
 --
 
 CREATE FUNCTION public.account_inventory_update() RETURNS trigger
     LANGUAGE plpgsql
-    AS $$  BEGIN    insert into account_inventory           (address,           balance, nonce,           dc_balance, dc_nonce,           security_balance, security_nonce,           first_block, last_block)    VALUES          (NEW.address,          NEW.balance, NEW.nonce,          NEW.dc_balance, NEW.dc_nonce,          NEW.security_balance, NEW.security_nonce,          NEW.block, NEW.block          )    ON CONFLICT (address) DO UPDATE SET         balance = EXCLUDED.balance,         nonce = EXCLUDED.nonce,         dc_balance = EXCLUDED.dc_balance,         dc_nonce = EXCLUDED.dc_nonce,         security_balance = EXCLUDED.security_balance,         security_nonce = EXCLUDED.security_nonce,         last_block = EXCLUDED.last_block;   RETURN NEW;  END;  $$;
+    AS $$  BEGIN    insert into account_inventory           (address,           balance, nonce,           dc_balance, dc_nonce,           security_balance, security_nonce,           staked_balance,           first_block, last_block)    VALUES          (NEW.address,          NEW.balance, NEW.nonce,          NEW.dc_balance, NEW.dc_nonce,          NEW.security_balance, NEW.security_nonce,          NEW.staked_balance,          NEW.block, NEW.block          )    ON CONFLICT (address) DO UPDATE SET         balance = EXCLUDED.balance,         nonce = EXCLUDED.nonce,         dc_balance = EXCLUDED.dc_balance,         dc_nonce = EXCLUDED.dc_nonce,         security_balance = EXCLUDED.security_balance,         security_nonce = EXCLUDED.security_nonce,         staked_balance = EXCLUDED.staked_balance,         last_block = EXCLUDED.last_block;   RETURN NEW;  END;  $$;
 
+
+ALTER FUNCTION public.account_inventory_update() OWNER TO etl;
 
 --
 -- Name: gateway_inventory_update(); Type: FUNCTION; Schema: public; Owner: etl
@@ -171,8 +310,21 @@ CREATE FUNCTION public.account_inventory_update() RETURNS trigger
 
 CREATE FUNCTION public.gateway_inventory_update() RETURNS trigger
     LANGUAGE plpgsql
-    AS $$ BEGIN   insert into gateway_inventory          (address, name, owner, location, alpha, beta, delta, score,           last_poc_challenge, last_poc_onion_key_hash, witnesses, nonce,           first_block, last_block, first_timestamp)   VALUES         (NEW.address, NEW.name, NEW.owner, NEW.location, NEW.alpha, NEW.beta, NEW.delta, NEW.score,         NEW.last_poc_challenge, NEW.last_poc_onion_key_hash, NEW.witnesses, NEW.nonce,         NEW.block, NEW.block, to_timestamp(NEW.time)         )   ON CONFLICT (address) DO UPDATE SET        owner = EXCLUDED.owner,        location = EXCLUDED.location,        alpha = EXCLUDED.alpha,        beta = EXCLUDED.beta,        delta = EXCLUDED.delta,        score = EXCLUDED.score,        last_poc_challenge = EXCLUDED.last_poc_challenge,        last_poc_onion_key_hash = EXCLUDED.last_poc_onion_key_hash,        witnesses = EXCLUDED.witnesses,        nonce = EXCLUDED.nonce,        last_block = EXCLUDED.last_block;   RETURN NEW; END; $$;
+    AS $$ BEGIN   insert into gateway_inventory as g          (address, name, owner, location,           last_poc_challenge, last_poc_onion_key_hash, witnesses, nonce,           first_block, last_block, first_timestamp, reward_scale,           elevation, gain, location_hex, mode)   VALUES         (NEW.address, NEW.name, NEW.owner, NEW.location,         NEW.last_poc_challenge, NEW.last_poc_onion_key_hash, NEW.witnesses, NEW.nonce,         NEW.block, NEW.block, to_timestamp(NEW.time), NEW.reward_scale,         NEW.elevation, NEW.gain,         NEW.location_hex, NEW.mode         )   ON CONFLICT (address) DO UPDATE SET        owner = EXCLUDED.owner,        location = EXCLUDED.location,        last_poc_challenge = EXCLUDED.last_poc_challenge,        last_poc_onion_key_hash = EXCLUDED.last_poc_onion_key_hash,        witnesses = EXCLUDED.witnesses,        nonce = EXCLUDED.nonce,        last_block = EXCLUDED.last_block,        reward_scale = COALESCE(EXCLUDED.reward_scale, g.reward_scale),        elevation = EXCLUDED.elevation,        gain = EXCLUDED.gain,        location_hex = EXCLUDED.location_hex;   RETURN NEW; END; $$;
 
+
+ALTER FUNCTION public.gateway_inventory_update() OWNER TO etl;
+
+--
+-- Name: insert_packets(); Type: FUNCTION; Schema: public; Owner: etl
+--
+
+CREATE FUNCTION public.insert_packets() RETURNS void
+    LANGUAGE plpgsql
+    AS $$ declare     txn RECORD; begin     for txn in         select *         from transactions where type = 'state_channel_close_v1'         order by block asc     loop         insert into packets (block, transaction_hash, time, gateway, num_packets, num_dcs)         select              txn.block, txn.hash, txn.time, client as gateway,              sum(num_packets)::bigint as num_packets,              sum(num_dcs)::bigint as num_dcs         from jsonb_populate_recordset(null::packet_entry, txn.fields#>'{state_channel, summaries}')         group by client;     end loop; end; $$;
+
+
+ALTER FUNCTION public.insert_packets() OWNER TO etl;
 
 --
 -- Name: insert_rewards(); Type: FUNCTION; Schema: public; Owner: etl
@@ -183,6 +335,8 @@ CREATE FUNCTION public.insert_rewards() RETURNS void
     AS $$ declare     txn RECORD; begin     for txn in         select *         from transactions where type = 'rewards_v1'         order by block asc     loop         insert into rewards (block, transaction_hash, time, account, gateway, amount)         select txn.block, txn.hash, txn.time, account, coalesce(gateway, '1Wh4bh') as gateway, sum(amount)::bigint as amount         from jsonb_populate_recordset(null::reward_entry, txn.fields->'rewards')         group by (account, gateway);     end loop; end; $$;
 
 
+ALTER FUNCTION public.insert_rewards() OWNER TO etl;
+
 --
 -- Name: last_agg(anyelement, anyelement); Type: FUNCTION; Schema: public; Owner: etl
 --
@@ -191,6 +345,8 @@ CREATE FUNCTION public.last_agg(anyelement, anyelement) RETURNS anyelement
     LANGUAGE sql IMMUTABLE STRICT
     AS $_$         SELECT $2; $_$;
 
+
+ALTER FUNCTION public.last_agg(anyelement, anyelement) OWNER TO etl;
 
 SET default_tablespace = '';
 
@@ -211,9 +367,12 @@ CREATE TABLE public.locations (
     long_country text,
     short_country text,
     search_city text,
-    city_id text
+    city_id text,
+    geometry public.geometry(Point,4326)
 );
 
+
+ALTER TABLE public.locations OWNER TO etl;
 
 --
 -- Name: location_city_id(public.locations); Type: FUNCTION; Schema: public; Owner: etl
@@ -224,6 +383,8 @@ CREATE FUNCTION public.location_city_id(l public.locations) RETURNS text
     AS $$ begin     return lower(coalesce(l.long_city, '') || coalesce(l.long_state, '') || coalesce(l.long_country, '')); end; $$;
 
 
+ALTER FUNCTION public.location_city_id(l public.locations) OWNER TO etl;
+
 --
 -- Name: location_city_id_update(); Type: FUNCTION; Schema: public; Owner: etl
 --
@@ -232,6 +393,8 @@ CREATE FUNCTION public.location_city_id_update() RETURNS trigger
     LANGUAGE plpgsql
     AS $$ begin     NEW.city_id := location_city_id(NEW);     return NEW; end; $$;
 
+
+ALTER FUNCTION public.location_city_id_update() OWNER TO etl;
 
 --
 -- Name: location_city_words(public.locations); Type: FUNCTION; Schema: public; Owner: etl
@@ -242,6 +405,8 @@ CREATE FUNCTION public.location_city_words(l public.locations) RETURNS text
     AS $$ begin     return (select string_agg(distinct word, ' ')             from regexp_split_to_table(                     lower(                         coalesce(l.long_city, '') || ' ' || coalesce(l.short_city, '') || ' ' ||                         coalesce(l.long_state, '') || ' ' || coalesce(l.short_state, '') || ' ' ||                         coalesce(l.long_country, '') || ' ' || coalesce(l.short_country, '') || ' '                     ) , '\s'                  ) as word where length(word) >= 3); end; $$;
 
 
+ALTER FUNCTION public.location_city_words(l public.locations) OWNER TO etl;
+
 --
 -- Name: location_search_city_update(); Type: FUNCTION; Schema: public; Owner: etl
 --
@@ -250,6 +415,19 @@ CREATE FUNCTION public.location_search_city_update() RETURNS trigger
     LANGUAGE plpgsql
     AS $$ begin     NEW.search_city := location_city_words(NEW);     return NEW; end; $$;
 
+
+ALTER FUNCTION public.location_search_city_update() OWNER TO etl;
+
+--
+-- Name: oui_inventory_update(); Type: FUNCTION; Schema: public; Owner: etl
+--
+
+CREATE FUNCTION public.oui_inventory_update() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$  BEGIN    insert into oui_inventory         (oui, owner,         nonce, addresses, subnets,         first_block, last_block)    VALUES         (NEW.oui, NEW.owner,         NEW.nonce, NEW.addresses, NEW.subnets,         NEW.block, NEW.block)    ON CONFLICT (oui) DO UPDATE SET         owner = EXCLUDED.owner,         nonce = EXCLUDED.nonce,         addresses = EXCLUDED.addresses,         subnets = EXCLUDED.subnets,         last_block = EXCLUDED.last_block;   RETURN NEW;  END;  $$;
+
+
+ALTER FUNCTION public.oui_inventory_update() OWNER TO etl;
 
 --
 -- Name: state_channel_counts(public.transaction_type, jsonb); Type: FUNCTION; Schema: public; Owner: etl
@@ -260,6 +438,8 @@ CREATE FUNCTION public.state_channel_counts(type public.transaction_type, fields
     AS $$ begin     case         when type = 'state_channel_close_v1' then             select into num_packets, num_dcs sum(x.num_packets), sum(x.num_dcs)             from jsonb_to_recordset(fields#>'{state_channel, summaries}') as x(owner TEXT, client TEXT, num_dcs BIGINT, location TEXT, num_packets BIGINT);         else             num_packets := 0;             num_dcs := 0;     end case; end;  $$;
 
 
+ALTER FUNCTION public.state_channel_counts(type public.transaction_type, fields jsonb, OUT num_packets numeric, OUT num_dcs numeric) OWNER TO etl;
+
 --
 -- Name: trigger_set_updated_at(); Type: FUNCTION; Schema: public; Owner: etl
 --
@@ -268,6 +448,8 @@ CREATE FUNCTION public.trigger_set_updated_at() RETURNS trigger
     LANGUAGE plpgsql
     AS $$ BEGIN   NEW.updated_at = NOW();   RETURN NEW; END; $$;
 
+
+ALTER FUNCTION public.trigger_set_updated_at() OWNER TO etl;
 
 --
 -- Name: txn_filter_account_activity(text, public.transaction_type, jsonb); Type: FUNCTION; Schema: public; Owner: etl
@@ -278,14 +460,18 @@ CREATE FUNCTION public.txn_filter_account_activity(acc text, type public.transac
     AS $$ begin     case         when type = 'rewards_v1' then             return jsonb_set(fields, '{rewards}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{rewards}') as x(account text, amount bigint, type text, gateway text) where account = acc));         when type = 'payment_v2' then             if fields#>'{payer}' = acc then                 return fields;             else                 return jsonb_set(fields, '{payees}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{payees}') as x(payee text, amount bigint) where payee = acc));             end if;         else             return fields;     end case; end; $$;
 
 
+ALTER FUNCTION public.txn_filter_account_activity(acc text, type public.transaction_type, fields jsonb) OWNER TO etl;
+
 --
 -- Name: txn_filter_actor_activity(text, public.transaction_type, jsonb); Type: FUNCTION; Schema: public; Owner: etl
 --
 
 CREATE FUNCTION public.txn_filter_actor_activity(actor text, type public.transaction_type, fields jsonb) RETURNS jsonb
     LANGUAGE plpgsql
-    AS $$ begin     case         when type = 'rewards_v1' then             return jsonb_set(fields, '{rewards}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{rewards}') as x(account text, amount bigint, type text, gateway text) where account = actor or gateway = actor));         when type = 'payment_v2' then             if fields->>'payer' = actor then                 return fields;             else                 return jsonb_set(fields, '{payments}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{payments}') as x(payee text, amount bigint) where payee = actor));             end if;         when type = 'consensus_group_v1' then            return fields - 'proof';         else             return fields;     end case; end; $$;
+    AS $$ begin     case         when type = 'rewards_v1' then             return jsonb_set(fields, '{rewards}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{rewards}') as x(account text, amount bigint, type text, gateway text) where account = actor or gateway = actor));         when type = 'rewards_v2' then             return jsonb_set(fields, '{rewards}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{rewards}') as x(account text, amount bigint, type text, gateway text) where account = actor or gateway = actor));         when type = 'state_channel_close_v1' then             return jsonb_set(fields, '{state_channel,summaries}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{state_channel,summaries}') as x(owner text, num_packets bigint, num_dcs bigint, location text, client text) where owner = actor or client = actor));         when type = 'payment_v2' then             if fields->>'payer' = actor then                 return fields;             else                 return jsonb_set(fields, '{payments}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{payments}') as x(payee text, amount bigint) where payee = actor));             end if;         when type = 'consensus_group_v1' then            return fields - 'proof';         else             return fields;     end case; end; $$;
 
+
+ALTER FUNCTION public.txn_filter_actor_activity(actor text, type public.transaction_type, fields jsonb) OWNER TO etl;
 
 --
 -- Name: txn_filter_gateway_activity(text, public.transaction_type, jsonb); Type: FUNCTION; Schema: public; Owner: etl
@@ -295,6 +481,32 @@ CREATE FUNCTION public.txn_filter_gateway_activity(gw text, type public.transact
     LANGUAGE plpgsql
     AS $$ begin     case         when type = 'rewards_v1' then             return jsonb_set(fields, '{rewards}', (select jsonb_agg(x) from jsonb_to_recordset(fields#>'{rewards}') as x(account text, amount bigint, type text, gateway text) where gateway = gw));         when type = 'consensus_group_v1' then            return fields - 'proof';         else             return fields;     end case; end; $$;
 
+
+ALTER FUNCTION public.txn_filter_gateway_activity(gw text, type public.transaction_type, fields jsonb) OWNER TO etl;
+
+--
+-- Name: validator_inventory_update(); Type: FUNCTION; Schema: public; Owner: etl
+--
+
+CREATE FUNCTION public.validator_inventory_update() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$  BEGIN    insert into validator_inventory           (address, name, owner,           stake, status, nonce,           last_heartbeat, version_heartbeat,           penalty, penalties,           first_block, last_block)    VALUES          (NEW.address, NEW.name, NEW.owner,          NEW.stake, NEW.status, NEW.nonce,          NEW.last_heartbeat, NEW.version_heartbeat,          NEW.penalty, NEW.penalties,          NEW.block, NEW.block          )    ON CONFLICT (address) DO UPDATE SET         stake = EXCLUDED.stake,         status = EXCLUDED.status,         owner = EXCLUDED.owner,         nonce = EXCLUDED.nonce,         last_heartbeat = EXCLUDED.last_heartbeat,         version_heartbeat = EXCLUDED.version_heartbeat,         penalty = EXCLUDED.penalty,         penalties = EXCLUDED.penalties,         last_block = EXCLUDED.last_block;   RETURN NEW;  END;  $$;
+
+
+ALTER FUNCTION public.validator_inventory_update() OWNER TO etl;
+
+--
+-- Name: jsonb_merge_agg(jsonb); Type: AGGREGATE; Schema: public; Owner: etl
+--
+
+CREATE AGGREGATE public.jsonb_merge_agg(jsonb) (
+    SFUNC = jsonb_concat,
+    STYPE = jsonb,
+    INITCOND = '{}'
+);
+
+
+ALTER AGGREGATE public.jsonb_merge_agg(jsonb) OWNER TO etl;
 
 --
 -- Name: last(anyelement); Type: AGGREGATE; Schema: public; Owner: etl
@@ -306,6 +518,8 @@ CREATE AGGREGATE public.last(anyelement) (
 );
 
 
+ALTER AGGREGATE public.last(anyelement) OWNER TO etl;
+
 --
 -- Name: __migrations; Type: TABLE; Schema: public; Owner: etl
 --
@@ -315,6 +529,8 @@ CREATE TABLE public.__migrations (
     datetime timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 
+
+ALTER TABLE public.__migrations OWNER TO etl;
 
 --
 -- Name: account_inventory; Type: TABLE; Schema: public; Owner: etl
@@ -329,9 +545,12 @@ CREATE TABLE public.account_inventory (
     security_balance bigint NOT NULL,
     security_nonce bigint NOT NULL,
     first_block bigint,
-    last_block bigint
+    last_block bigint,
+    staked_balance bigint
 );
 
+
+ALTER TABLE public.account_inventory OWNER TO etl;
 
 --
 -- Name: accounts; Type: TABLE; Schema: public; Owner: etl
@@ -345,9 +564,12 @@ CREATE TABLE public.accounts (
     security_balance bigint DEFAULT 0 NOT NULL,
     security_nonce bigint DEFAULT 0 NOT NULL,
     balance bigint DEFAULT 0 NOT NULL,
-    nonce bigint DEFAULT 0 NOT NULL
+    nonce bigint DEFAULT 0 NOT NULL,
+    staked_balance bigint
 );
 
+
+ALTER TABLE public.accounts OWNER TO etl;
 
 --
 -- Name: block_signatures; Type: TABLE; Schema: public; Owner: etl
@@ -359,6 +581,8 @@ CREATE TABLE public.block_signatures (
     signature text NOT NULL
 );
 
+
+ALTER TABLE public.block_signatures OWNER TO etl;
 
 --
 -- Name: blocks; Type: TABLE; Schema: public; Owner: etl
@@ -380,6 +604,8 @@ CREATE TABLE public.blocks (
 );
 
 
+ALTER TABLE public.blocks OWNER TO etl;
+
 --
 -- Name: transactions; Type: TABLE; Schema: public; Owner: etl
 --
@@ -393,6 +619,233 @@ CREATE TABLE public.transactions (
 );
 
 
+ALTER TABLE public.transactions OWNER TO etl;
+
+--
+-- Name: challenge_receipts; Type: VIEW; Schema: public; Owner: etl
+--
+
+CREATE VIEW public.challenge_receipts AS
+ SELECT transactions.block,
+    transactions.hash,
+    transactions.type,
+    (transactions.fields ->> 'challenger'::text) AS challenger,
+    (transactions.fields ->> 'challenger_location'::text) AS challenger_location,
+    (transactions.fields ->> 'challenger_owner'::text) AS challenger_owner,
+    (transactions.fields ->> 'fee'::text) AS fee,
+    (transactions.fields ->> 'onion_key_hash'::text) AS onion_key_hash,
+    (transactions.fields ->> 'path'::text) AS path,
+    (transactions.fields ->> 'secret'::text) AS secret,
+    to_timestamp((transactions."time")::double precision) AS "time"
+   FROM public.transactions
+  WHERE (transactions.type = 'poc_receipts_v1'::public.transaction_type);
+
+
+ALTER TABLE public.challenge_receipts OWNER TO etl;
+
+--
+-- Name: challenge_receipts_parsed; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.challenge_receipts_parsed (
+    block bigint,
+    hash text,
+    "time" timestamp with time zone,
+    transmitter_name text,
+    transmitter_address text,
+    origin text,
+    witness_owner text,
+    witness_name text,
+    witness_gateway text,
+    witness_is_valid text,
+    witness_invalid_reason text,
+    witness_signal text,
+    witness_snr text,
+    witness_channel text,
+    witness_datarate text,
+    witness_frequency text,
+    witness_location text,
+    witness_timestamp text
+);
+
+
+ALTER TABLE public.challenge_receipts_parsed OWNER TO etl;
+
+--
+-- Name: challenge_receipts_parsed_old; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.challenge_receipts_parsed_old (
+    block bigint,
+    hash text,
+    "time" timestamp with time zone,
+    transmitter_name text,
+    transmitter_address text,
+    origin text,
+    witness_owner text,
+    witness_name text,
+    witness_gateway text,
+    witness_is_valid text,
+    witness_invalid_reason text,
+    witness_signal text,
+    witness_snr text,
+    witness_channel text,
+    witness_datarate text,
+    witness_frequency text,
+    witness_location text,
+    witness_timestamp text
+);
+
+
+ALTER TABLE public.challenge_receipts_parsed_old OWNER TO etl;
+
+--
+-- Name: challenge_requests; Type: VIEW; Schema: public; Owner: etl
+--
+
+CREATE VIEW public.challenge_requests AS
+ SELECT transactions.block,
+    transactions.hash,
+    transactions.type,
+    (transactions.fields ->> 'block_hash'::text) AS block_hash,
+    (transactions.fields ->> 'challenger'::text) AS challenger,
+    (transactions.fields ->> 'challenger_location'::text) AS challenger_location,
+    (transactions.fields ->> 'challenger_owner'::text) AS challenger_owner,
+    (transactions.fields ->> 'fee'::text) AS fee,
+    (transactions.fields ->> 'onion_key_hash'::text) AS onion_key_hash,
+    (transactions.fields ->> 'secret_hash'::text) AS secret_hash,
+    (transactions.fields ->> 'version'::text) AS version,
+    to_timestamp((transactions."time")::double precision) AS "time"
+   FROM public.transactions
+  WHERE (transactions.type = 'poc_request_v1'::public.transaction_type);
+
+
+ALTER TABLE public.challenge_requests OWNER TO etl;
+
+--
+-- Name: cheatnets; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.cheatnets (
+    address character varying NOT NULL,
+    rating integer DEFAULT 0,
+    created_at timestamp(6) without time zone NOT NULL
+);
+
+
+ALTER TABLE public.cheatnets OWNER TO etl;
+
+--
+-- Name: rewards; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.rewards (
+    block bigint NOT NULL,
+    transaction_hash text NOT NULL,
+    "time" bigint NOT NULL,
+    account text NOT NULL,
+    gateway text NOT NULL,
+    amount bigint NOT NULL
+)
+WITH (autovacuum_enabled='true');
+
+
+ALTER TABLE public.rewards OWNER TO etl;
+
+--
+-- Name: cheatnet_rewards; Type: MATERIALIZED VIEW; Schema: public; Owner: etl
+--
+
+CREATE MATERIALIZED VIEW public.cheatnet_rewards AS
+ SELECT rewards.account,
+    rewards.gateway,
+    rewards.amount,
+    (to_timestamp((rewards."time")::double precision))::timestamp without time zone AS "timestamp"
+   FROM (public.cheatnets
+     LEFT JOIN public.rewards ON ((rewards.account = (cheatnets.address)::text)))
+  WITH NO DATA;
+
+
+ALTER TABLE public.cheatnet_rewards OWNER TO etl;
+
+--
+-- Name: data_credits; Type: MATERIALIZED VIEW; Schema: public; Owner: etl
+--
+
+CREATE MATERIALIZED VIEW public.data_credits AS
+ WITH second AS (
+         WITH first AS (
+                 SELECT transactions.type,
+                    ((transactions.fields -> 'state_channel'::text) -> 'summaries'::text) AS sums,
+                    to_timestamp((transactions."time")::double precision) AS "time"
+                   FROM public.transactions
+                  WHERE (transactions.type = 'state_channel_close_v1'::public.transaction_type)
+                 LIMIT 1048576
+                )
+         SELECT first.sums AS summaries,
+            date_trunc('day'::text, first."time") AS "time"
+           FROM first
+        )
+ SELECT second."time",
+    (json_array_elements(to_json(second.summaries)) ->> 'owner'::text) AS owner,
+    (json_array_elements(to_json(second.summaries)) ->> 'client'::text) AS client,
+    (json_array_elements(to_json(second.summaries)) ->> 'location'::text) AS location,
+    ((json_array_elements(to_json(second.summaries)) ->> 'num_dcs'::text))::integer AS dcs,
+    ((json_array_elements(to_json(second.summaries)) ->> 'num_packets'::text))::integer AS packets
+   FROM second
+  WITH NO DATA;
+
+
+ALTER TABLE public.data_credits OWNER TO etl;
+
+--
+-- Name: data_credits_with_locations; Type: VIEW; Schema: public; Owner: etl
+--
+
+CREATE VIEW public.data_credits_with_locations AS
+ SELECT data_credits."time",
+    data_credits.owner,
+    data_credits.client,
+    data_credits.location,
+    data_credits.dcs,
+    data_credits.packets,
+    locations.long_street,
+    locations.short_street,
+    locations.long_city,
+    locations.short_city,
+    locations.long_state,
+    locations.short_state,
+    locations.long_country,
+    locations.short_country,
+    locations.search_city,
+    locations.city_id,
+    locations.geometry,
+    public.st_y(locations.geometry) AS lat,
+    public.st_x(locations.geometry) AS long
+   FROM (public.data_credits
+     LEFT JOIN public.locations locations ON ((data_credits.location = locations.location)))
+  WHERE (locations.geometry IS NOT NULL);
+
+
+ALTER TABLE public.data_credits_with_locations OWNER TO etl;
+
+--
+-- Name: dc_burns; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.dc_burns (
+    block bigint,
+    transaction_hash text NOT NULL,
+    actor text NOT NULL,
+    type public.burn_type NOT NULL,
+    amount bigint NOT NULL,
+    oracle_price bigint,
+    "time" bigint
+);
+
+
+ALTER TABLE public.dc_burns OWNER TO etl;
+
 --
 -- Name: gateway_inventory; Type: TABLE; Schema: public; Owner: etl
 --
@@ -401,10 +854,6 @@ CREATE TABLE public.gateway_inventory (
     address text NOT NULL,
     owner text NOT NULL,
     location text,
-    alpha double precision NOT NULL,
-    beta double precision NOT NULL,
-    delta integer NOT NULL,
-    score double precision NOT NULL,
     last_poc_challenge bigint,
     last_poc_onion_key_hash text,
     witnesses jsonb NOT NULL,
@@ -412,9 +861,16 @@ CREATE TABLE public.gateway_inventory (
     last_block bigint,
     nonce bigint,
     name text,
-    first_timestamp timestamp with time zone
+    first_timestamp timestamp with time zone,
+    reward_scale double precision,
+    elevation integer,
+    gain integer,
+    location_hex text,
+    mode public.gateway_mode
 );
 
+
+ALTER TABLE public.gateway_inventory OWNER TO etl;
 
 --
 -- Name: gateway_status; Type: TABLE; Schema: public; Owner: etl
@@ -427,9 +883,12 @@ CREATE TABLE public.gateway_status (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     poc_interval bigint,
     last_challenge bigint,
-    peer_timestamp timestamp with time zone
+    peer_timestamp timestamp with time zone,
+    listen_addrs jsonb
 );
 
+
+ALTER TABLE public.gateway_status OWNER TO etl;
 
 --
 -- Name: gateways; Type: TABLE; Schema: public; Owner: etl
@@ -440,18 +899,68 @@ CREATE TABLE public.gateways (
     address text NOT NULL,
     owner text NOT NULL,
     location text,
-    alpha double precision NOT NULL,
-    beta double precision NOT NULL,
-    delta integer NOT NULL,
-    score double precision NOT NULL,
     last_poc_challenge bigint,
     last_poc_onion_key_hash text,
     witnesses jsonb NOT NULL,
     nonce bigint,
     name text,
-    "time" bigint
+    "time" bigint,
+    reward_scale double precision,
+    elevation integer,
+    gain integer,
+    location_hex text,
+    mode public.gateway_mode
 );
 
+
+ALTER TABLE public.gateways OWNER TO etl;
+
+--
+-- Name: maker_address; Type: VIEW; Schema: public; Owner: wishplorer
+--
+
+CREATE VIEW public.maker_address AS
+ SELECT 'Helium Inc'::text AS maker,
+    '13daGGWvDQyTyHFDCPz8zDSVTWgPNNfJ4oh31Teec4TRWfjMx53'::text AS address
+UNION
+ SELECT 'Cal-Chip Connected Devices'::text AS maker,
+    '13ENbEQPAvytjLnqavnbSAzurhGoCSNkGECMx7eHHDAfEaDirdY'::text AS address
+UNION
+ SELECT 'Maker Integration Tests'::text AS maker,
+    '138LbePH4r7hWPuTnK6HXVJ8ATM2QU71iVHzLTup1UbnPDvbxmr'::text AS address
+UNION
+ SELECT 'Nebra Ltd'::text AS maker,
+    '13Zni1he7KY9pUmkXMhEhTwfUpL9AcEV1m2UbbvFsrU9QPTMgE3'::text AS address
+UNION
+ SELECT 'SyncroB.it'::text AS maker,
+    '14rb2UcfS9U89QmKswpZpjRCUVCVu1haSyqyGY486EvsYtvdJmR'::text AS address
+UNION
+ SELECT 'Bobcat'::text AS maker,
+    '14sKWeeYWQWrBSnLGq79uRQqZyw3Ldi7oBdxbF6a54QboTNBXDL'::text AS address
+UNION
+ SELECT 'LongAP'::text AS maker,
+    '12zX4jgDGMbJgRwmCfRNGXBuphkQRqkUTcLzYHTQvd4Qgu8kiL4'::text AS address
+UNION
+ SELECT 'Smart Mimic'::text AS maker,
+    '13MS2kZHU4h6wp3tExgoHdDFjBsb9HB9JBvcbK9XmfNyJ7jqzVv'::text AS address
+UNION
+ SELECT 'RAKwireless'::text AS maker,
+    '14h2zf1gEr9NmvDb2U53qucLN2jLrKU1ECBoxGnSnQ6tiT6V2kM'::text AS address
+UNION
+ SELECT 'Kerlink'::text AS maker,
+    '13Mpg5hCNjSxHJvWjaanwJPBuTXu1d4g5pGvGBkqQe3F8mAwXhK'::text AS address
+UNION
+ SELECT 'DeWi Foundation'::text AS maker,
+    '13LVwCqZEKLTVnf3sjGPY1NMkTE7fWtUVjmDfeuscMFgeK3f9pn'::text AS address
+UNION
+ SELECT 'SenseCAP'::text AS maker,
+    '14NBXJE5kAAZTMigY4dcjXSMG4CSqjYwvteQWwQsYhsu2TKN6AF'::text AS address
+UNION
+ SELECT 'Helium Inc (old)'::text AS maker,
+    '14fzfjFcHpDR1rTH8BNPvSi5dKBbgxaDnmsVPbCjuq9ENjpZbxh'::text AS address;
+
+
+ALTER TABLE public.maker_address OWNER TO wishplorer;
 
 --
 -- Name: oracle_inventory; Type: TABLE; Schema: public; Owner: etl
@@ -461,6 +970,8 @@ CREATE TABLE public.oracle_inventory (
     address text NOT NULL
 );
 
+
+ALTER TABLE public.oracle_inventory OWNER TO etl;
 
 --
 -- Name: oracle_price_predictions; Type: TABLE; Schema: public; Owner: etl
@@ -472,6 +983,27 @@ CREATE TABLE public.oracle_price_predictions (
 );
 
 
+ALTER TABLE public.oracle_price_predictions OWNER TO etl;
+
+--
+-- Name: oracle_price_transactions; Type: VIEW; Schema: public; Owner: etl
+--
+
+CREATE VIEW public.oracle_price_transactions AS
+ SELECT transactions.block,
+    transactions.hash,
+    transactions.type,
+    ((transactions.fields ->> 'fee'::text))::bigint AS fee,
+    ((transactions.fields ->> 'price'::text))::bigint AS price,
+    (transactions.fields ->> 'public_key'::text) AS public_key,
+    (transactions.fields ->> 'block_height'::text) AS block_height,
+    to_timestamp((transactions."time")::double precision) AS "time"
+   FROM public.transactions
+  WHERE (transactions.type = 'price_oracle_v1'::public.transaction_type);
+
+
+ALTER TABLE public.oracle_price_transactions OWNER TO etl;
+
 --
 -- Name: oracle_prices; Type: TABLE; Schema: public; Owner: etl
 --
@@ -481,6 +1013,57 @@ CREATE TABLE public.oracle_prices (
     price bigint NOT NULL
 );
 
+
+ALTER TABLE public.oracle_prices OWNER TO etl;
+
+--
+-- Name: oui_inventory; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.oui_inventory (
+    oui bigint NOT NULL,
+    owner text NOT NULL,
+    nonce bigint NOT NULL,
+    addresses text[] NOT NULL,
+    subnets integer[] NOT NULL,
+    first_block bigint,
+    last_block bigint
+);
+
+
+ALTER TABLE public.oui_inventory OWNER TO etl;
+
+--
+-- Name: ouis; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.ouis (
+    block bigint NOT NULL,
+    oui bigint NOT NULL,
+    owner text NOT NULL,
+    nonce bigint NOT NULL,
+    addresses text[] NOT NULL,
+    subnets integer[] NOT NULL
+);
+
+
+ALTER TABLE public.ouis OWNER TO etl;
+
+--
+-- Name: packets; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.packets (
+    block bigint NOT NULL,
+    transaction_hash text NOT NULL,
+    "time" bigint NOT NULL,
+    gateway text NOT NULL,
+    num_packets bigint NOT NULL,
+    num_dcs bigint NOT NULL
+);
+
+
+ALTER TABLE public.packets OWNER TO etl;
 
 --
 -- Name: pending_transaction_actors; Type: TABLE; Schema: public; Owner: etl
@@ -493,6 +1076,8 @@ CREATE TABLE public.pending_transaction_actors (
     created_at timestamp with time zone NOT NULL
 );
 
+
+ALTER TABLE public.pending_transaction_actors OWNER TO etl;
 
 --
 -- Name: pending_transactions; Type: TABLE; Schema: public; Owner: etl
@@ -513,20 +1098,7 @@ CREATE TABLE public.pending_transactions (
 );
 
 
---
--- Name: rewards; Type: TABLE; Schema: public; Owner: etl
---
-
-CREATE TABLE public.rewards (
-    block bigint NOT NULL,
-    transaction_hash text NOT NULL,
-    "time" bigint NOT NULL,
-    account text NOT NULL,
-    gateway text NOT NULL,
-    amount bigint NOT NULL
-)
-WITH (autovacuum_enabled='true');
-
+ALTER TABLE public.pending_transactions OWNER TO etl;
 
 --
 -- Name: stats_inventory; Type: TABLE; Schema: public; Owner: etl
@@ -537,6 +1109,8 @@ CREATE TABLE public.stats_inventory (
     value bigint DEFAULT 0 NOT NULL
 );
 
+
+ALTER TABLE public.stats_inventory OWNER TO etl;
 
 --
 -- Name: transaction_actors; Type: TABLE; Schema: public; Owner: etl
@@ -550,6 +1124,174 @@ CREATE TABLE public.transaction_actors (
 );
 
 
+ALTER TABLE public.transaction_actors OWNER TO etl;
+
+--
+-- Name: transactions_assert_location; Type: VIEW; Schema: public; Owner: etl
+--
+
+CREATE VIEW public.transactions_assert_location AS
+ SELECT transactions.block,
+    transactions.hash,
+    transactions.type,
+    (transactions.fields ->> 'fee'::text) AS fee,
+    ((transactions.fields ->> 'nonce'::text))::integer AS nonce,
+    (transactions.fields ->> 'owner'::text) AS owner,
+    (transactions.fields ->> 'payer'::text) AS payer,
+    (transactions.fields ->> 'gateway'::text) AS gateway,
+    (transactions.fields ->> 'location'::text) AS location,
+    (transactions.fields ->> 'staking_fee'::text) AS staking_fee,
+    to_timestamp((transactions."time")::double precision) AS "time"
+   FROM public.transactions
+  WHERE (transactions.type = 'assert_location_v1'::public.transaction_type);
+
+
+ALTER TABLE public.transactions_assert_location OWNER TO etl;
+
+--
+-- Name: transactions_exploded; Type: VIEW; Schema: public; Owner: etl
+--
+
+CREATE VIEW public.transactions_exploded AS
+ SELECT transactions.block,
+    transactions.hash,
+    transactions.type,
+    ((transactions.fields ->> 'fee'::text))::bigint AS fee,
+    ((transactions.fields ->> 'price'::text))::bigint AS price,
+    (transactions.fields ->> 'public_key'::text) AS public_key,
+    (transactions.fields ->> 'block_height'::text) AS block_height,
+    ((transactions.fields ->> 'nonce'::text))::integer AS nonce,
+    (transactions.fields ->> 'owner'::text) AS owner,
+    (transactions.fields ->> 'payer'::text) AS payer,
+    (transactions.fields ->> 'gateway'::text) AS gateway,
+    (transactions.fields ->> 'location'::text) AS location,
+    (transactions.fields ->> 'staking_fee'::text) AS staking_fee,
+    (transactions.fields ->> 'block_hash'::text) AS block_hash,
+    (transactions.fields ->> 'challenger'::text) AS challenger,
+    (transactions.fields ->> 'challenger_location'::text) AS challenger_location,
+    (transactions.fields ->> 'challenger_owner'::text) AS challenger_owner,
+    (transactions.fields ->> 'onion_key_hash'::text) AS onion_key_hash,
+    (transactions.fields ->> 'secret_hash'::text) AS secret_hash,
+    ((transactions.fields ->> 'version'::text))::integer AS version,
+    (transactions.fields ->> 'path'::text) AS path,
+    (transactions.fields ->> 'secret'::text) AS secret,
+    to_timestamp((transactions."time")::double precision) AS "time"
+   FROM public.transactions;
+
+
+ALTER TABLE public.transactions_exploded OWNER TO etl;
+
+--
+-- Name: transactions_transfer_hotspot; Type: VIEW; Schema: public; Owner: etl
+--
+
+CREATE VIEW public.transactions_transfer_hotspot AS
+ SELECT transactions.block,
+    transactions.hash,
+    transactions.type,
+    (transactions.fields ->> 'buyer'::text) AS buyer,
+    (transactions.fields ->> 'seller'::text) AS seller,
+    (transactions.fields ->> 'gateway'::text) AS gateway,
+    ((transactions.fields ->> 'buyer_nonce'::text))::integer AS buyer_nonce,
+    ((transactions.fields ->> 'amount_to_seller'::text))::bigint AS amount_to_seller,
+    to_timestamp((transactions."time")::double precision) AS "time"
+   FROM public.transactions
+  WHERE (transactions.type = 'transfer_hotspot_v1'::public.transaction_type);
+
+
+ALTER TABLE public.transactions_transfer_hotspot OWNER TO etl;
+
+--
+-- Name: validator_inventory; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.validator_inventory (
+    address text NOT NULL,
+    name text NOT NULL,
+    owner text NOT NULL,
+    status public.validator_status_type NOT NULL,
+    stake bigint DEFAULT 0 NOT NULL,
+    nonce bigint NOT NULL,
+    last_heartbeat bigint,
+    version_heartbeat bigint NOT NULL,
+    penalty double precision DEFAULT 0 NOT NULL,
+    penalties jsonb,
+    first_block bigint,
+    last_block bigint
+);
+
+
+ALTER TABLE public.validator_inventory OWNER TO etl;
+
+--
+-- Name: validator_penalty_parsed; Type: VIEW; Schema: public; Owner: wishplorer
+--
+
+CREATE VIEW public.validator_penalty_parsed AS
+ WITH data1 AS (
+         SELECT a.address,
+            a.name,
+            a.owner,
+            b.value AS cpen
+           FROM public.validator_inventory a,
+            LATERAL json_array_elements((a.penalties)::json) b(value)
+        ), data2 AS (
+         SELECT data1.address,
+            data1.name,
+            data1.owner,
+            (data1.cpen ->> 'type'::text) AS penalty_type,
+            ((data1.cpen ->> 'amount'::text))::double precision AS penalty_amount,
+            ((data1.cpen ->> 'height'::text))::bigint AS penalty_height
+           FROM data1
+        )
+ SELECT data2.address,
+    data2.name,
+    data2.owner,
+    data2.penalty_type,
+    data2.penalty_amount,
+    data2.penalty_height
+   FROM data2;
+
+
+ALTER TABLE public.validator_penalty_parsed OWNER TO wishplorer;
+
+--
+-- Name: validator_status; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.validator_status (
+    address text NOT NULL,
+    online public.validator_status_online,
+    block bigint,
+    peer_timestamp timestamp with time zone,
+    listen_addrs jsonb,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.validator_status OWNER TO etl;
+
+--
+-- Name: validators; Type: TABLE; Schema: public; Owner: etl
+--
+
+CREATE TABLE public.validators (
+    block bigint NOT NULL,
+    address text NOT NULL,
+    name text NOT NULL,
+    owner text NOT NULL,
+    status public.validator_status_type NOT NULL,
+    stake bigint DEFAULT 0 NOT NULL,
+    nonce bigint NOT NULL,
+    last_heartbeat bigint,
+    version_heartbeat bigint NOT NULL,
+    penalty double precision DEFAULT 0 NOT NULL,
+    penalties jsonb
+);
+
+
+ALTER TABLE public.validators OWNER TO etl;
+
 --
 -- Name: vars_inventory; Type: TABLE; Schema: public; Owner: etl
 --
@@ -560,6 +1302,8 @@ CREATE TABLE public.vars_inventory (
     value text NOT NULL
 );
 
+
+ALTER TABLE public.vars_inventory OWNER TO etl;
 
 --
 -- Name: __migrations __migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
@@ -599,6 +1343,14 @@ ALTER TABLE ONLY public.block_signatures
 
 ALTER TABLE ONLY public.blocks
     ADD CONSTRAINT blocks_pkey PRIMARY KEY (height);
+
+
+--
+-- Name: dc_burns dc_burns_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.dc_burns
+    ADD CONSTRAINT dc_burns_pkey PRIMARY KEY (actor, transaction_hash, type);
 
 
 --
@@ -650,6 +1402,30 @@ ALTER TABLE ONLY public.oracle_price_predictions
 
 
 --
+-- Name: oui_inventory oui_inventory_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.oui_inventory
+    ADD CONSTRAINT oui_inventory_pkey PRIMARY KEY (oui);
+
+
+--
+-- Name: ouis ouis_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.ouis
+    ADD CONSTRAINT ouis_pkey PRIMARY KEY (block, oui);
+
+
+--
+-- Name: packets packets_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.packets
+    ADD CONSTRAINT packets_pkey PRIMARY KEY (block, transaction_hash, gateway);
+
+
+--
 -- Name: pending_transaction_actors pending_transaction_actors_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
 --
 
@@ -698,6 +1474,30 @@ ALTER TABLE ONLY public.transactions
 
 
 --
+-- Name: validator_inventory validator_inventory_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.validator_inventory
+    ADD CONSTRAINT validator_inventory_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: validator_status validator_status_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.validator_status
+    ADD CONSTRAINT validator_status_pkey PRIMARY KEY (address);
+
+
+--
+-- Name: validators validators_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.validators
+    ADD CONSTRAINT validators_pkey PRIMARY KEY (block, address);
+
+
+--
 -- Name: vars_inventory vars_inventory_pkey; Type: CONSTRAINT; Schema: public; Owner: etl
 --
 
@@ -731,6 +1531,76 @@ CREATE INDEX account_inventory_first_block ON public.account_inventory USING btr
 --
 
 CREATE INDEX blocks_snapshot_idx ON public.blocks USING btree (snapshot_hash);
+
+
+--
+-- Name: challenge_receipts_parsed2_transmitter_address_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX challenge_receipts_parsed2_transmitter_address_idx ON public.challenge_receipts_parsed USING btree (transmitter_address);
+
+
+--
+-- Name: challenge_receipts_parsed2_transmitter_name_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX challenge_receipts_parsed2_transmitter_name_idx ON public.challenge_receipts_parsed USING btree (transmitter_name);
+
+
+--
+-- Name: challenge_receipts_parsed2_witness_name_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX challenge_receipts_parsed2_witness_name_idx ON public.challenge_receipts_parsed USING btree (witness_name);
+
+
+--
+-- Name: challenge_receipts_parsed_transmitter_address_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX challenge_receipts_parsed_transmitter_address_idx ON public.challenge_receipts_parsed_old USING btree (transmitter_address);
+
+
+--
+-- Name: challenge_receipts_parsed_transmitter_name_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX challenge_receipts_parsed_transmitter_name_idx ON public.challenge_receipts_parsed_old USING btree (transmitter_name);
+
+
+--
+-- Name: challenge_receipts_parsed_witness_name_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX challenge_receipts_parsed_witness_name_idx ON public.challenge_receipts_parsed_old USING btree (witness_name);
+
+
+--
+-- Name: cheatnet_rewards_account_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX cheatnet_rewards_account_idx ON public.cheatnet_rewards USING btree (account);
+
+
+--
+-- Name: cheatnet_rewards_gateway_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX cheatnet_rewards_gateway_idx ON public.cheatnet_rewards USING btree (gateway);
+
+
+--
+-- Name: data_credits_client_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX data_credits_client_idx ON public.data_credits USING btree (client);
+
+
+--
+-- Name: dc_burns_block_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX dc_burns_block_idx ON public.dc_burns USING brin ("time");
 
 
 --
@@ -790,10 +1660,24 @@ CREATE INDEX gateway_owner_idx ON public.gateways USING btree (owner);
 
 
 --
+-- Name: gateway_search_name_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX gateway_search_name_idx ON public.gateway_inventory USING gin (name public.gin_trgm_ops);
+
+
+--
 -- Name: gateway_status_updated_at_idx; Type: INDEX; Schema: public; Owner: etl
 --
 
 CREATE INDEX gateway_status_updated_at_idx ON public.gateway_status USING btree (updated_at);
+
+
+--
+-- Name: index_cheatnets_on_address; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE UNIQUE INDEX index_cheatnets_on_address ON public.cheatnets USING btree (address);
 
 
 --
@@ -818,6 +1702,34 @@ CREATE INDEX oracle_prices_block_idx ON public.oracle_prices USING btree (block)
 
 
 --
+-- Name: oui_inventory_first_block; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX oui_inventory_first_block ON public.oui_inventory USING btree (first_block);
+
+
+--
+-- Name: oui_owner_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX oui_owner_idx ON public.oui_inventory USING btree (owner);
+
+
+--
+-- Name: packets_block_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX packets_block_idx ON public.packets USING btree (block);
+
+
+--
+-- Name: packets_gateway_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX packets_gateway_idx ON public.packets USING btree (gateway);
+
+
+--
 -- Name: pending_transaction_hash_idx; Type: INDEX; Schema: public; Owner: etl
 --
 
@@ -839,17 +1751,17 @@ CREATE INDEX rewards_account_idx ON public.rewards USING btree (account);
 
 
 --
--- Name: rewards_block_idx; Type: INDEX; Schema: public; Owner: etl
---
-
-CREATE INDEX rewards_block_idx ON public.rewards USING btree (block);
-
-
---
 -- Name: rewards_gateway_idx; Type: INDEX; Schema: public; Owner: etl
 --
 
 CREATE INDEX rewards_gateway_idx ON public.rewards USING btree (gateway);
+
+
+--
+-- Name: rewards_time_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX rewards_time_idx ON public.rewards USING brin ("time");
 
 
 --
@@ -902,6 +1814,41 @@ CREATE INDEX transaction_type_idx ON public.transactions USING btree (type);
 
 
 --
+-- Name: validator_inventory_first_block; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX validator_inventory_first_block ON public.validator_inventory USING btree (first_block);
+
+
+--
+-- Name: validator_name_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX validator_name_idx ON public.validator_inventory USING btree (name);
+
+
+--
+-- Name: validator_owner_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX validator_owner_idx ON public.validator_inventory USING btree (owner);
+
+
+--
+-- Name: validator_search_name_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX validator_search_name_idx ON public.validator_inventory USING gin (name public.gin_trgm_ops);
+
+
+--
+-- Name: validator_status_updated_at_idx; Type: INDEX; Schema: public; Owner: etl
+--
+
+CREATE INDEX validator_status_updated_at_idx ON public.validator_status USING btree (updated_at);
+
+
+--
 -- Name: accounts account_insert; Type: TRIGGER; Schema: public; Owner: etl
 --
 
@@ -937,10 +1884,31 @@ CREATE TRIGGER location_update_search_city BEFORE INSERT ON public.locations FOR
 
 
 --
+-- Name: ouis oui_insert; Type: TRIGGER; Schema: public; Owner: etl
+--
+
+CREATE TRIGGER oui_insert AFTER INSERT ON public.ouis FOR EACH ROW EXECUTE PROCEDURE public.oui_inventory_update();
+
+
+--
 -- Name: pending_transactions pending_transaction_set_updated_at; Type: TRIGGER; Schema: public; Owner: etl
 --
 
 CREATE TRIGGER pending_transaction_set_updated_at BEFORE UPDATE ON public.pending_transactions FOR EACH ROW EXECUTE PROCEDURE public.trigger_set_updated_at();
+
+
+--
+-- Name: validators validator_insert; Type: TRIGGER; Schema: public; Owner: etl
+--
+
+CREATE TRIGGER validator_insert AFTER INSERT ON public.validators FOR EACH ROW EXECUTE PROCEDURE public.validator_inventory_update();
+
+
+--
+-- Name: validator_status validator_status_set_updated_at; Type: TRIGGER; Schema: public; Owner: etl
+--
+
+CREATE TRIGGER validator_status_set_updated_at BEFORE UPDATE ON public.validator_status FOR EACH ROW EXECUTE PROCEDURE public.trigger_set_updated_at();
 
 
 --
@@ -973,6 +1941,22 @@ ALTER TABLE ONLY public.accounts
 
 ALTER TABLE ONLY public.block_signatures
     ADD CONSTRAINT block_signatures_block_fkey FOREIGN KEY (block) REFERENCES public.blocks(height) ON DELETE CASCADE;
+
+
+--
+-- Name: dc_burns dc_burns_block_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.dc_burns
+    ADD CONSTRAINT dc_burns_block_fkey FOREIGN KEY (block) REFERENCES public.blocks(height);
+
+
+--
+-- Name: dc_burns dc_burns_transaction_hash_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.dc_burns
+    ADD CONSTRAINT dc_burns_transaction_hash_fkey FOREIGN KEY (transaction_hash) REFERENCES public.transactions(hash) ON DELETE CASCADE;
 
 
 --
@@ -1032,6 +2016,46 @@ ALTER TABLE ONLY public.oracle_prices
 
 
 --
+-- Name: oui_inventory oui_inventory_first_block_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.oui_inventory
+    ADD CONSTRAINT oui_inventory_first_block_fkey FOREIGN KEY (first_block) REFERENCES public.blocks(height) ON DELETE SET NULL;
+
+
+--
+-- Name: oui_inventory oui_inventory_last_block_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.oui_inventory
+    ADD CONSTRAINT oui_inventory_last_block_fkey FOREIGN KEY (last_block) REFERENCES public.blocks(height) ON DELETE SET NULL;
+
+
+--
+-- Name: ouis ouis_block_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.ouis
+    ADD CONSTRAINT ouis_block_fkey FOREIGN KEY (block) REFERENCES public.blocks(height) ON DELETE CASCADE;
+
+
+--
+-- Name: packets packets_block_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.packets
+    ADD CONSTRAINT packets_block_fkey FOREIGN KEY (block) REFERENCES public.blocks(height) ON DELETE CASCADE;
+
+
+--
+-- Name: packets packets_transaction_hash_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.packets
+    ADD CONSTRAINT packets_transaction_hash_fkey FOREIGN KEY (transaction_hash) REFERENCES public.transactions(hash);
+
+
+--
 -- Name: pending_transaction_actors pending_transaction_actors_created_at_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
 --
 
@@ -1078,6 +2102,334 @@ ALTER TABLE ONLY public.transaction_actors
 ALTER TABLE ONLY public.transactions
     ADD CONSTRAINT transactions_block_fkey FOREIGN KEY (block) REFERENCES public.blocks(height) ON DELETE CASCADE;
 
+
+--
+-- Name: validator_inventory validator_inventory_first_block_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.validator_inventory
+    ADD CONSTRAINT validator_inventory_first_block_fkey FOREIGN KEY (first_block) REFERENCES public.blocks(height) ON DELETE SET NULL;
+
+
+--
+-- Name: validator_inventory validator_inventory_last_block_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.validator_inventory
+    ADD CONSTRAINT validator_inventory_last_block_fkey FOREIGN KEY (last_block) REFERENCES public.blocks(height) ON DELETE SET NULL;
+
+
+--
+-- Name: validator_inventory validator_inventory_last_heartbeat_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.validator_inventory
+    ADD CONSTRAINT validator_inventory_last_heartbeat_fkey FOREIGN KEY (last_heartbeat) REFERENCES public.blocks(height) ON DELETE SET NULL;
+
+
+--
+-- Name: validator_status validator_status_address_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.validator_status
+    ADD CONSTRAINT validator_status_address_fkey FOREIGN KEY (address) REFERENCES public.validator_inventory(address) ON DELETE CASCADE;
+
+
+--
+-- Name: validators validators_block_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.validators
+    ADD CONSTRAINT validators_block_fkey FOREIGN KEY (block) REFERENCES public.blocks(height) ON DELETE CASCADE;
+
+
+--
+-- Name: validators validators_last_heartbeat_fkey; Type: FK CONSTRAINT; Schema: public; Owner: etl
+--
+
+ALTER TABLE ONLY public.validators
+    ADD CONSTRAINT validators_last_heartbeat_fkey FOREIGN KEY (last_heartbeat) REFERENCES public.blocks(height) ON DELETE CASCADE;
+
+
+--
+-- Name: SCHEMA public; Type: ACL; Schema: -; Owner: postgres
+--
+
+GRANT USAGE ON SCHEMA public TO readaccess;
+
+
+--
+-- Name: TABLE locations; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.locations TO readaccess;
+
+
+--
+-- Name: TABLE __migrations; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.__migrations TO readaccess;
+
+
+--
+-- Name: TABLE account_inventory; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.account_inventory TO readaccess;
+
+
+--
+-- Name: TABLE accounts; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.accounts TO readaccess;
+
+
+--
+-- Name: TABLE block_signatures; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.block_signatures TO readaccess;
+
+
+--
+-- Name: TABLE blocks; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.blocks TO readaccess;
+
+
+--
+-- Name: TABLE transactions; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.transactions TO readaccess;
+
+
+--
+-- Name: TABLE challenge_receipts; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.challenge_receipts TO readaccess;
+
+
+--
+-- Name: TABLE challenge_receipts_parsed; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.challenge_receipts_parsed TO readaccess;
+
+
+--
+-- Name: TABLE challenge_receipts_parsed_old; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.challenge_receipts_parsed_old TO readaccess;
+
+
+--
+-- Name: TABLE challenge_requests; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.challenge_requests TO readaccess;
+
+
+--
+-- Name: TABLE cheatnets; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.cheatnets TO readaccess;
+
+
+--
+-- Name: TABLE rewards; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.rewards TO readaccess;
+
+
+--
+-- Name: TABLE cheatnet_rewards; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.cheatnet_rewards TO readaccess;
+
+
+--
+-- Name: TABLE data_credits; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.data_credits TO readaccess;
+
+
+--
+-- Name: TABLE data_credits_with_locations; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.data_credits_with_locations TO readaccess;
+
+
+--
+-- Name: TABLE dc_burns; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.dc_burns TO readaccess;
+
+
+--
+-- Name: TABLE gateway_inventory; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.gateway_inventory TO readaccess;
+
+
+--
+-- Name: TABLE gateway_status; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.gateway_status TO readaccess;
+
+
+--
+-- Name: TABLE gateways; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.gateways TO readaccess;
+
+
+--
+-- Name: TABLE oracle_inventory; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.oracle_inventory TO readaccess;
+
+
+--
+-- Name: TABLE oracle_price_predictions; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.oracle_price_predictions TO readaccess;
+
+
+--
+-- Name: TABLE oracle_price_transactions; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.oracle_price_transactions TO readaccess;
+
+
+--
+-- Name: TABLE oracle_prices; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.oracle_prices TO readaccess;
+
+
+--
+-- Name: TABLE oui_inventory; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.oui_inventory TO readaccess;
+
+
+--
+-- Name: TABLE ouis; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.ouis TO readaccess;
+
+
+--
+-- Name: TABLE packets; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.packets TO readaccess;
+
+
+--
+-- Name: TABLE pending_transaction_actors; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.pending_transaction_actors TO readaccess;
+
+
+--
+-- Name: TABLE pending_transactions; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.pending_transactions TO readaccess;
+
+
+--
+-- Name: TABLE stats_inventory; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.stats_inventory TO readaccess;
+
+
+--
+-- Name: TABLE transaction_actors; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.transaction_actors TO readaccess;
+
+
+--
+-- Name: TABLE transactions_assert_location; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.transactions_assert_location TO readaccess;
+
+
+--
+-- Name: TABLE transactions_exploded; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.transactions_exploded TO readaccess;
+
+
+--
+-- Name: TABLE transactions_transfer_hotspot; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.transactions_transfer_hotspot TO readaccess;
+
+
+--
+-- Name: TABLE validator_inventory; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.validator_inventory TO readaccess;
+
+
+--
+-- Name: TABLE validator_status; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.validator_status TO readaccess;
+
+
+--
+-- Name: TABLE validators; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.validators TO readaccess;
+
+
+--
+-- Name: TABLE vars_inventory; Type: ACL; Schema: public; Owner: etl
+--
+
+GRANT SELECT ON TABLE public.vars_inventory TO readaccess;
+
+
+--
+-- Name: DEFAULT PRIVILEGES FOR TABLES; Type: DEFAULT ACL; Schema: public; Owner: etl
+--
+
+ALTER DEFAULT PRIVILEGES FOR ROLE etl IN SCHEMA public REVOKE ALL ON TABLES  FROM etl;
+ALTER DEFAULT PRIVILEGES FOR ROLE etl IN SCHEMA public GRANT SELECT ON TABLES  TO readaccess;
 
 
 --

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # 
-# assumes you have postgres credentials in the ENV already
-# PGUSER, PGPASSWORD et al
+# assumes you have postgres credentials in the ENV already, e.g. PGUSER, PGPASSWORD et al
+#
+# to update `etl-schema.sql`, run this on an up-to-date ETL instance:
+#
+#   pg_dump -s etl > etl-schema.sql
 # 
 
 database="etl_queries_test"

--- a/views/validator_cg_members.sql
+++ b/views/validator_cg_members.sql
@@ -1,0 +1,8 @@
+drop view if exists validator_cg_members;
+create view validator_cg_members as
+    select address as address,
+    count(penalty_type) as cg_count
+    from validator_penalty_parsed
+    where penalty_type = 'tenure'
+    group by address;
+


### PR DESCRIPTION
We are re-using this in a lot of queries in the Validator dashboard, might as well make it properly shared

One issue: this view depends on `validator_penalties_parsed`! How can we ensure that view is loaded before this one? Maybe using some explicit view-load commands in migrations/?

Might be time for [dbt](https://github.com/dbt-labs/dbt)
