### PR TITLE
Rename and add index for witness_address/gateway

### DIFF
--- a/migrations/0004_add_missing_index_to_challenge_receipts_parsed.sql
+++ b/migrations/0004_add_missing_index_to_challenge_receipts_parsed.sql
@@ -1,0 +1,8 @@
+-- this table has indexes on name + address for transmitter, but only on name for witness
+-- this adds the missing `witness_gateway` index
+-- arguably should only be indexing on address, since names are not garaunteed to be unique
+
+ALTER TABLE challenge_receipts_parsed RENAME COLUMN "witness_gateway" TO "witness_address";
+
+DROP INDEX IF EXISTS challenge_receipts_parsed_witness_address_idx;
+CREATE INDEX challenge_receipts_parsed_witness_address_idx ON public.challenge_receipts_parsed USING btree (witness_address);


### PR DESCRIPTION
challenge_receipts_parsed has 4 fields we use a bit:
- transmitter_name
- transmitter_address
- witness_name
- witness_gateway 

This PR

- renames witness_gateway to witness_address, for consistency
- adds an index for the newly-renamed witness_address, which was not present before and queries were slooooooow

I'd also argue we should drop the indexes on both _name fields, since those are not garaunteed to be unique and easy to look up using a simple subselect

Fixes #12