### PR TITLE
Add payment_transactions view

### DIFF
--- a/views/payment_transactions.sql
+++ b/views/payment_transactions.sql
@@ -1,0 +1,16 @@
+drop view if exists payment_transactions;
+create view payment_transactions as
+	select 
+			block
+			-- , hash
+			-- , type
+			, fields::json->>'fee' as fee
+			, fields::json->>'hash' as hash
+			, fields::json->>'type' as type
+			, fields::json->>'nonce' as nonce
+			, fields::json->>'payee' as payee
+			, fields::json->>'payer' as payer
+			, fields::json->>'amount' as amount    
+	from transactions 
+	where type IN ('payment_v1', 'payment_v2');
+

--- a/views/transactions_payment.sql
+++ b/views/transactions_payment.sql
@@ -1,5 +1,5 @@
-drop view if exists payment_transactions;
-create view payment_transactions as
+drop view if exists transactions_payment;
+create view transactions_payment as
 	select 
 			block
 			-- , hash


### PR DESCRIPTION
Extracts the JSON into native columns for better integration with Metabase

I went with "payment_transactions" instead of "transaction_payments" because it felt more natural. Is the latter better for consistency, so it's more clear that all these views are based off `transactions`?
