### PR TITLE
Update type to poc_receipts_v2

### DIFF
--- a/views/challenge_receipts.sql
+++ b/views/challenge_receipts.sql
@@ -6,18 +6,14 @@ SELECT
 
     -- fields specific to this txn
     public.transactions.fields->>'challenger' as challenger,
-    public.transactions.fields->>'challenger_location' as challenger_location,
     public.transactions.fields->>'challenger_owner' as challenger_owner,
-    public.transactions.fields->>'fee' as fee,
-    -- public.transactions.fields->>'hash' as hash,
     public.transactions.fields->>'onion_key_hash' as onion_key_hash,
     public.transactions.fields->>'path' as path,
     public.transactions.fields->>'secret' as secret,
-    -- public.transactions.fields->>'type' as type,
 
     to_timestamp(public.transactions.time) AS time
 FROM
   public.transactions
 WHERE
-  public.transactions.type = CAST('poc_receipts_v1' AS transaction_type)
+  public.transactions.type = CAST('poc_receipts_v2' AS transaction_type)
 ;


### PR DESCRIPTION
Also removes `challenger_location` which is no longer tracked in the txn fields (this is now a validator)